### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,8 @@ release: build
 		echo "ERROR: '$(NT)' is not a valid semver tag (expected format: vX.Y.Z[-prerelease])"; \
 		exit 1; \
 	fi
+	@if git rev-parse -q --verify "refs/tags/$(NT)" >/dev/null 2>&1; then echo "ERROR: tag $(NT) already exists locally. Pick a new version or delete it: git tag -d $(NT)"; exit 1; fi
+	@if git ls-remote --exit-code --tags origin "refs/tags/$(NT)" >/dev/null 2>&1; then echo "ERROR: tag $(NT) already exists on origin. Pick a new version."; exit 1; fi
 	@echo -n "Are you sure to create and push ${NT} tag? [y/N] " && read ans && [ $${ans:-N} = y ]
 	@echo ${NT} > ./version.txt
 	@git add -A


### PR DESCRIPTION
The `release` recipe wrote `version.txt` and ran `git commit` before `git tag`, with no check that the target tag was free. Re-running with an already-published tag would land a dangling "Cut vX release" commit while `git tag` aborted — a half-published release (Makefile Safety Check #16).

**Fix:** add a fail-before-mutation guard right after semver validation and before the confirm prompt — reject the tag if it exists locally (`git rev-parse --verify`) or on origin (`git ls-remote --tags`). Preserves the recipe's separate `@`-line style; no happy-path change.

Verified: guard fires before any commit/tag against an existing tag (`v0.0.9`), leaving `git status` clean; `make -n release` parses cleanly.